### PR TITLE
Correct hxml to build test sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ __Possible Future Platforms__:
 Set up the sites and run them
 
 ```
-haxe requestresponsetester.hxml
+haxe testsites.hxml
 cd out/neko_nocache/
 nekotools server -rewrite
 ```


### PR DESCRIPTION
It seems that testsites.hxml is the correct script to build the test sites, while requestresponsetester.hxml builds the tests.
